### PR TITLE
Anchor Destination Expand on Click Implementation

### DIFF
--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -617,7 +617,8 @@ export class UrlReplacements {
    * @param {!function(!string, Error):void} callback upon expansion or
    *    timeout/error given current expansion value from click target anchor
    *    href and optional error.
-   * @param {Promise<string>}
+   * @param {Promise<string>} if value resolves to string then redirect to its
+   *    value
    * @private
    */
   getExpandAnchorHref_(evt) {
@@ -679,9 +680,13 @@ export class UrlReplacements {
       if (currHref != href) {
         href = currHref;
         if (!href || !href.indexOf('#')) {
+          // Href no longer a valid destination so return null to indicate
+          // no redirect.
           return Promise.resolve(null);
         }
       }
+      // Return expansion result promise out timeout depending on which
+      // resolves first.
       return timer.timeoutPromise(50, this.expand_(href, vars, null, regExp))
           .catch(() => {
             // On error (either due to timeout or error resolving field)

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -636,11 +636,25 @@ export class UrlReplacements {
     if (!href || !href.indexOf('#')) {
       return Promise.resolve(null);
     }
-    let vars = {'CLICK_X': '', 'CLICK_Y': ''};
+    const vars = {
+      'CLICK_X': (function() {
+        if (evt.clientX === undefined) {
+          return '';
+        }
+        return evt.clientX - this.getShadowHostOffset_(evt.target).left;
+      }).bind(this),
+      'CLICK_Y': (function() {
+        if (evt.clientY === undefined) {
+          return '';
+        }
+        return evt.clientY - this.getShadowHostOffset_(evt.target).top;
+      }).bind(this)
+    };
+
     // As optimization, do not bother continuing if current href does not
     // contain an expansion key.  It is possible the href could be modified by
     // a later listener but we will assume it is unlikely to add a key.
-    let regExp = this.getExpr_(vars);
+    const regExp = this.getExpr_(vars);
     if (!regExp.test(href)) {
       return Promise.resolve(null);
     }
@@ -667,16 +681,6 @@ export class UrlReplacements {
         if (!href || !href.indexOf('#')) {
           return Promise.resolve(null);
         }
-      }
-      let shadowHostOffset;
-      if (evt.clientX !== undefined) {
-        shadowHostOffset = this.getShadowHostOffset_(evt.target);
-        vars['CLICK_X'] = evt.clientX - shadowHostOffset.left;
-      }
-      if (evt.clientY !== undefined) {
-        shadowHostOffset =
-          shadowHostOffset || this.getShadowHostOffset_(evt.target);
-        vars['CLICK_Y'] = evt.clientY - shadowHostOffset.top;
       }
       return timer.timeoutPromise(50, this.expand_(href, vars, null, regExp))
           .catch(() => {


### PR DESCRIPTION
Registers document click listener that allows for expansion for anchor href to be used for eventual navigation.  See intent to implement #3665 