### PR TITLE
Modified CSI pings to now emit QEM (when available), and to use corre…

### DIFF
--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -30,6 +30,7 @@ import {
 import {isExperimentOn} from '../../../src/experiments';
 import {dev} from '../../../src/log';
 import {getMode} from '../../../src/mode';
+import {getCorrelator}from './utils';
 
 /**
  * This module provides a fairly crude form of performance monitoring (or
@@ -109,7 +110,7 @@ function isInReportableBranch(ampElement, namespace) {
 /**
  * @return {!GoogleAdLifecycleReporter|!NullLifecycleReporter}
  */
-export function getLifecycleReporter(ampElement, namespace) {
+export function getLifecycleReporter(ampElement, namespace, slotId) {
   // Carve-outs: We only want to enable profiling pingbacks when:
   //   - The ad is from one of the Google networks (AdSense or Doubleclick).
   //   - The ad slot is in the A4A-vs-3p amp-ad control branch (either via
@@ -132,7 +133,8 @@ export function getLifecycleReporter(ampElement, namespace) {
   if ((type == 'doubleclick' || type == 'adsense') &&
       isInReportableBranch(ampElement, namespace) &&
       isExperimentOn(win, 'a4aProfilingRate')) {
-    return new GoogleAdLifecycleReporter(win, ampElement.element, 'a4a');
+    return new GoogleAdLifecycleReporter(win, ampElement.element, 'a4a',
+        getCorrelator(win, slotId), slotId);
   } else {
     return new NullLifecycleReporter();
   }

--- a/ads/google/a4a/performance.js
+++ b/ads/google/a4a/performance.js
@@ -189,20 +189,6 @@ export class GoogleAdLifecycleReporter {
   }
 
   /**
-   * @returns {number} The slot ID.
-   */
-  getSlotId() {
-    return this.slotId_;
-  }
-
-  /**
-   * @returns {number} The correlator.
-   */
-  getCorrelator() {
-    return this.correlator_;
-  }
-
-  /**
    * @param {string} name  Metric name to send.
    * @returns {string}  URL to send metrics to.
    * @private

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -15,7 +15,6 @@
  */
 
 import {buildUrl} from './url-builder';
-import {getLifecycleReporter} from './performance';
 import {makeCorrelator} from '../correlator';
 import {getAdCid} from '../../../src/ad-cid';
 import {documentInfoForDoc} from '../../../src/document-info';
@@ -308,10 +307,12 @@ function elapsedTimeWithCeiling(time, start) {
   return '-M';
 }
 
-export function constructLifecycleReporter(win, element) {
-  const correlator = win.ampAdPageCorrelator || makeCorrelator(this.slotId_,
-      documentInfoForDoc(this.element_).pageViewId);
-  win.ampAdSlotIdCounter = win.ampAdSlotIdCounter || 0;
-  const slotId = win.ampAdSlotIdCounter++;
-  return getLifecycleReporter(win, element, 'a4a', correlator, slotId);
+/**
+ * @param {!Window} win
+ * @param {number} slotId
+ * @return {number} The correlator.
+ */
+export function getCorrelator(win, slotId) {
+  return win.ampAdPageCorrelator || makeCorrelator(slotId,
+        documentInfoForDoc(win.document).pageViewId);
 }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -313,6 +313,9 @@ function elapsedTimeWithCeiling(time, start) {
  * @return {number} The correlator.
  */
 export function getCorrelator(win, slotId) {
-  return win.ampAdPageCorrelator || makeCorrelator(slotId,
-        documentInfoForDoc(win.document).pageViewId);
+  if (!win.ampAdPageCorrelator) {
+    win.ampAdPageCorrelator = makeCorrelator(
+        slotId, documentInfoForDoc(win.document).pageViewId);
+  }
+  return win.ampAdPageCorrelator;
 }

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -15,6 +15,7 @@
  */
 
 import {buildUrl} from './url-builder';
+import {getLifecycleReporter} from './performance';
 import {makeCorrelator} from '../correlator';
 import {getAdCid} from '../../../src/ad-cid';
 import {documentInfoForDoc} from '../../../src/document-info';
@@ -305,4 +306,12 @@ function elapsedTimeWithCeiling(time, start) {
     return duration;
   }
   return '-M';
+}
+
+export function constructLifecycleReporter(win, element) {
+  const correlator = win.ampAdPageCorrelator || makeCorrelator(this.slotId_,
+      documentInfoForDoc(this.element_).pageViewId);
+  win.ampAdSlotIdCounter = win.ampAdSlotIdCounter || 0;
+  const slotId = win.ampAdSlotIdCounter++;
+  return getLifecycleReporter(win, element, 'a4a', correlator, slotId);
 }

--- a/ads/google/adsense.js
+++ b/ads/google/adsense.js
@@ -24,7 +24,8 @@ import {validateData} from '../../3p/3p';
 export function adsense(global, data) {
   // TODO: check mandatory fields
   validateData(data, [],
-      ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId']);
+      ['adClient', 'adSlot', 'adHost', 'adtest', 'tagOrigin', 'experimentId',
+       'slotId']);
 
   if (global.context.clientId) {
     // Read by GPT for GA/GPT integration.

--- a/ads/google/correlator.js
+++ b/ads/google/correlator.js
@@ -22,7 +22,6 @@
 export function makeCorrelator(clientId, pageViewId) {
   const pageViewIdNumeric = Number(pageViewId || 0);
   if (clientId) {
-    clientId = typeof clientId == 'string' ? clientId : String(clientId);
     return pageViewIdNumeric + (clientId.replace(/\D/g, '') % 1e6) * 1e6;
   } else {
     return pageViewIdNumeric;

--- a/ads/google/correlator.js
+++ b/ads/google/correlator.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @param {(string|undefined)} clientId
+ * @param {(string|number|undefined)} clientId
  * @param {string} pageViewId
  * @return {number}
  */

--- a/ads/google/correlator.js
+++ b/ads/google/correlator.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * @param {(string|number|undefined)} clientId
+ * @param {(string|undefined)} clientId
  * @param {string} pageViewId
  * @return {number}
  */

--- a/ads/google/correlator.js
+++ b/ads/google/correlator.js
@@ -22,6 +22,7 @@
 export function makeCorrelator(clientId, pageViewId) {
   const pageViewIdNumeric = Number(pageViewId || 0);
   if (clientId) {
+    clientId = typeof clientId == 'string' ? clientId : String(clientId);
     return pageViewIdNumeric + (clientId.replace(/\D/g, '') % 1e6) * 1e6;
   } else {
     return pageViewIdNumeric;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -121,8 +121,9 @@ export class AmpA4A extends AMP.BaseElement {
 
   /**
    * @param {!Element} element
+   * @param {!Ojbect=} opt_adContext
    */
-  constructor(element) {
+  constructor(element, opt_adContext) {
     super(element);
     dev().assert(AMP.AmpAdApiHandler);
 
@@ -137,6 +138,9 @@ export class AmpA4A extends AMP.BaseElement {
 
     /** {?Object} */
     this.config = null;
+
+    /** {?Object} */
+    this.adContext = opt_adContext;
 
     /** @private {?string} */
     this.adUrl_ = null;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -19,7 +19,10 @@ import {
   incrementLoadingAds,
 } from '../../amp-ad/0.1/concurrent-load';
 import {adConfig} from '../../../ads/_config';
-import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
+import {
+  getLifecycleReporter,
+  QQID_HEADER,
+} from '../../../ads/google/a4a/performance';
 import {signingServerURLs} from '../../../ads/_a4a-config';
 import {
   closestByTag,
@@ -321,6 +324,8 @@ export class AmpA4A extends AMP.BaseElement {
         // object), or null if no response is available / response is empty.
         /** @return {?Promise<?{bytes: !ArrayBuffer, headers: !Headers}>} */
         .then(fetchResponse => {
+          const qqid = fetchResponse.headers.get(QQID_HEADER);
+          this.lifecycleReporter.setQqid(qqid);
           checkStillCurrent(promiseId);
           if (!fetchResponse || !fetchResponse.arrayBuffer) {
             return null;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -20,8 +20,8 @@ import {
 } from '../../amp-ad/0.1/concurrent-load';
 import {adConfig} from '../../../ads/_config';
 import {
-  getLifecycleReporter,
   QQID_HEADER,
+  NullLifecycleReporter,
 } from '../../../ads/google/a4a/performance';
 import {signingServerURLs} from '../../../ads/_a4a-config';
 import {
@@ -167,8 +167,8 @@ export class AmpA4A extends AMP.BaseElement {
     /** @private {?string} */
     this.experimentalNonAmpCreativeRenderMethod_ = null;
 
-    /** {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
-    this.lifecycleReporter = getLifecycleReporter(this, 'a4a');
+    /** {!../../../ads/google/a4a/performance.GoogleAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
+    this.lifecycleReporter = this.initLifecycleReporter();
     // Note: The reporting ping should be the last action in the constructor.
     this.lifecycleReporter.sendPing('adSlotBuilt');
   }
@@ -508,6 +508,7 @@ export class AmpA4A extends AMP.BaseElement {
   /** @override  */
   unlayoutCallback() {
     this.lifecycleReporter.sendPing('adSlotCleared');
+    this.lifecycleReporter.reset();
     // Remove creative and reset to allow for creation of new ad.
     if (!this.layoutMeasureExecuted_) {
       return true;
@@ -1006,5 +1007,15 @@ export class AmpA4A extends AMP.BaseElement {
       }
       target.setAttribute('href', newHref);
     }
+  }
+
+  /**
+   * To be overridden by network specific implementation. If no implementation
+   * is provided, a NullLifecycleReporter will be returned.
+   *
+   * @return {!../../../ads/google/a4a/performance.GoogleAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter}
+   */
+  initLifecycleReporter() {
+    return new NullLifecycleReporter();
   }
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -29,6 +29,7 @@ import {
   getGoogleAdSlotCounter,
   googleAdUrl,
   isGoogleAdsA4AValidEnvironment,
+  constructLifecycleReporter,
 } from '../../../ads/google/a4a/utils';
 import {documentStateFor} from '../../../src/document-state';
 import {getMode} from '../../../src/mode';
@@ -117,6 +118,11 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       return ctypesReMatch[1];
     }
     return null;
+  }
+
+  /** @override */
+  initLifecycleReporter() {
+    return constructLifecycleReporter(window, this);
   }
 
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -29,6 +29,7 @@ import {
   getGoogleAdSlotCounter,
   googleAdUrl,
   isGoogleAdsA4AValidEnvironment,
+  constructLifecycleReporter,
 } from '../../../ads/google/a4a/utils';
 
 /** @const {string} */
@@ -88,6 +89,10 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     return extractGoogleAdCreativeAndSignature(responseText, responseHeaders);
   }
 
+  /** @override */
+  initLifecycleReporter() {
+    return constructLifecycleReporter(window, this);
+  }
 }
 
 AMP.registerElement(

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -40,10 +40,9 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /**
    * @param {!Element} element
-   * @param {!Object=} opt_adContext
    */
-  constructor(element, opt_adContext) {
-    super(element, opt_adContext);
+  constructor(element) {
+    super(element);
   }
 
   /** @override */
@@ -58,7 +57,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   getAdUrl() {
     const startTime = Date.now();
     const global = this.win;
-    const slotId = this.adContext.slotId;
+    const slotId = this.element.getAttribute('data-slot-id');
     const correlator = getCorrelator(global, slotId);
     const slotRect = this.getIntersectionElementLayoutBox();
     const rawJson = this.element.getAttribute('json');
@@ -95,8 +94,44 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
+  emitLifecycleEvent(eventName, opt_associatedEventData) {
+    if (!this.lifecycleReporter) {
+      this.lifecycleReporter = this.initLifecycleReporter();
+    }
+    switch (eventName) {
+      case 'adRequestEnd':
+        const fetchResponse = opt_associatedEventData;
+        const qqid = fetchResponse.headers.get(
+            this.lifecycleReporter.QQID_HEADER);
+        this.lifecycleReporter.setQqid(qqid);
+        break;
+      case 'adSlotCleared':
+        this.lifecycleReporter.sendPing(eventName);
+        this.lifecycleReporter.reset();
+        this.element.setAttribute('data-slot-id',
+            this.win.ampAdSlotIdCounter++);
+        this.lifecycleReporter = this.initLifecycleReporter();
+        return;
+      case 'adSlotBuilt':
+      case 'urlBuilt':
+      case 'adRequestStart':
+      case 'extractCreativeAndSignature':
+      case 'adResponseValidateStart':
+      case 'renderFriendlyStart':
+      case 'renderCrossDomainStart':
+      case 'renderFriendlyEnd':
+      case 'renderCrossDomainEnd':
+      case 'preAdThrottle':
+      case 'renderSafeFrameStart':
+        break;
+      default:
+    }
+    this.lifecycleReporter.sendPing(eventName);
+  }
+
   initLifecycleReporter() {
-    return getLifecycleReporter(this, 'a4a', this.adContext.slotId);
+    return getLifecycleReporter(this, 'a4a',
+        this.element.getAttribute('data-slot-id'));
   }
 }
 

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -89,9 +89,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     /** @private {?Promise} */
     this.layoutPromise_ = null;
 
-    /** {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
+    /** {!../../../ads/google/a4a/performance.BaseLifecycleReporter} */
     this.lifecycleReporter = getLifecycleReporter(this, 'amp',
-        this.adContext.slotId);
+        this.element.getAttribute('data-slot-id'));
 
     this.lifecycleReporter.sendPing('adSlotBuilt');
   }

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -27,6 +27,7 @@ import {isAdPositionAllowed, getAdContainer,}
     from '../../../src/ad-helper';
 import {adConfig} from '../../../ads/_config';
 import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
+import {constructLifecycleReporter} from '../../../ads/google/a4a/utils';
 import {user} from '../../../src/log';
 import {getIframe} from '../../../src/3p-frame';
 import {setupA2AListener} from './a2a-listener';
@@ -85,7 +86,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     this.layoutPromise_ = null;
 
     /** {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
-    this.lifecycleReporter = getLifecycleReporter(this, 'amp');
+    this.lifecycleReporter = constructLifecycleReporter(window, this);
 
     this.lifecycleReporter.sendPing('adSlotBuilt');
   }

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -39,9 +39,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
   /**
    * @param {!AmpElement} element
-   * @param {!Ojbect=} opt_adContext
    */
-  constructor(element, opt_adContext) {
+  constructor(element) {
     super(element);
 
     /** @private {?Element} */
@@ -49,9 +48,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
     /** {?Object} */
     this.config = null;
-
-    /** {?Object} */
-    this.adContext = opt_adContext || {};
 
     /** @private {?AmpAdApiHandler} */
     this.apiHandler_ = null;

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -212,6 +212,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       const opt_context = {
         clientId: cid || null,
         container: this.container_,
+        c: this.lifecycleReporter.getCorrelator(),
+        ifi: this.lifecycleReporter.getSlotId(),
       };
       // In this path, the request and render start events are entangled,
       // because both happen inside a cross-domain iframe.  Separating them

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -27,20 +27,21 @@ import {isAdPositionAllowed, getAdContainer,}
     from '../../../src/ad-helper';
 import {adConfig} from '../../../ads/_config';
 import {getLifecycleReporter} from '../../../ads/google/a4a/performance';
-import {constructLifecycleReporter} from '../../../ads/google/a4a/utils';
 import {user} from '../../../src/log';
 import {getIframe} from '../../../src/3p-frame';
 import {setupA2AListener} from './a2a-listener';
 import {moveLayoutRect} from '../../../src/layout-rect';
-
 
 /** @const {!string} Tag name for 3P AD implementation. */
 export const TAG_3P_IMPL = 'amp-ad-3p-impl';
 
 export class AmpAd3PImpl extends AMP.BaseElement {
 
-  /** @param {!AmpElement} element */
-  constructor(element) {
+  /**
+   * @param {!AmpElement} element
+   * @param {!Ojbect=} opt_adContext
+   */
+  constructor(element, opt_adContext) {
     super(element);
 
     /** @private {?Element} */
@@ -48,6 +49,9 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
     /** {?Object} */
     this.config = null;
+
+    /** {?Object} */
+    this.adContext = opt_adContext || {};
 
     /** @private {?AmpAdApiHandler} */
     this.apiHandler_ = null;
@@ -86,7 +90,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     this.layoutPromise_ = null;
 
     /** {!../../../ads/google/a4a/performance.AmpAdLifecycleReporter|!../../../ads/google/a4a/performance.NullLifecycleReporter} */
-    this.lifecycleReporter = constructLifecycleReporter(window, this);
+    this.lifecycleReporter = getLifecycleReporter(this, 'amp',
+        this.adContext.slotId);
 
     this.lifecycleReporter.sendPing('adSlotBuilt');
   }
@@ -213,9 +218,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
       const opt_context = {
         clientId: cid || null,
         container: this.container_,
-        c: this.lifecycleReporter.getCorrelator(),
-        ifi: this.lifecycleReporter.getSlotId(),
       };
+
       // In this path, the request and render start events are entangled,
       // because both happen inside a cross-domain iframe.  Separating them
       // here, though, allows us to measure the impact of ad throttling via

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -52,25 +52,30 @@ export class AmpAd extends AMP.BaseElement {
         // Unspecified or empty type.  Nothing to do here except bail out.
         return null;
       }
+      window.ampAdSlotIdCounter = window.ampAdSlotIdCounter || 0;
+      const slotId = window.ampAdSlotIdCounter++;
+      const adContext = {
+        slotId,
+      };
       // TODO(tdrl): Check amp-ad registry to see if they have this already.
       if (!a4aRegistry[type] ||
           !a4aRegistry[type](this.win, this.element)) {
         // Network either has not provided any A4A implementation or the
         // implementation exists, but has explicitly chosen not to handle this
         // tag as A4A.  Fall back to the 3p implementation.
-        return new AmpAd3PImpl(this.element);
+        return new AmpAd3PImpl(this.element, adContext);
       }
       const extensionTagName = networkImplementationTag(type);
       this.element.setAttribute('data-a4a-upgrade-type', extensionTagName);
       return extensionsFor(this.win).loadElementClass(extensionTagName)
-        .then(ctor => new ctor(this.element))
+        .then(ctor => new ctor(this.element, adContext))
         .catch(error => {
           // Work around presubmit restrictions.
           const TAG = this.element.tagName;
           // Report error and fallback to 3p
           user().error(TAG, 'Unable to load ad implementation for type ', type,
               ', falling back to 3p, error: ', error);
-          return new AmpAd3PImpl(this.element);
+          return new AmpAd3PImpl(this.element, adContext);
         });
     });
   }

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -54,28 +54,26 @@ export class AmpAd extends AMP.BaseElement {
       }
       window.ampAdSlotIdCounter = window.ampAdSlotIdCounter || 0;
       const slotId = window.ampAdSlotIdCounter++;
-      const adContext = {
-        slotId,
-      };
+      this.element.setAttribute('data-slot-id', slotId);
       // TODO(tdrl): Check amp-ad registry to see if they have this already.
       if (!a4aRegistry[type] ||
           !a4aRegistry[type](this.win, this.element)) {
         // Network either has not provided any A4A implementation or the
         // implementation exists, but has explicitly chosen not to handle this
         // tag as A4A.  Fall back to the 3p implementation.
-        return new AmpAd3PImpl(this.element, adContext);
+        return new AmpAd3PImpl(this.element);
       }
       const extensionTagName = networkImplementationTag(type);
       this.element.setAttribute('data-a4a-upgrade-type', extensionTagName);
       return extensionsFor(this.win).loadElementClass(extensionTagName)
-        .then(ctor => new ctor(this.element, adContext))
+        .then(ctor => new ctor(this.element))
         .catch(error => {
           // Work around presubmit restrictions.
           const TAG = this.element.tagName;
           // Report error and fallback to 3p
           user().error(TAG, 'Unable to load ad implementation for type ', type,
               ', falling back to 3p, error: ', error);
-          return new AmpAd3PImpl(this.element, adContext);
+          return new AmpAd3PImpl(this.element);
         });
     });
   }


### PR DESCRIPTION
…lator.js for generating correlator.

What's changed:

- Correlator value is now produced using correlator.js, documentInfo.pageViewId, and slotId.
- The A4A flow sets the QEM as soon as the ad response comes back.
- For 3p, I've added the correlator and slotId (as 'c' and 'ifi', resp.) to the iframe's attributes (through the opt_context variable), which automatically forces the values to be injected into the request URL.

What's (potentially missing):

- We spoke offline about what needs to happen in unlayoutCallback, but I'm not sure what that is. I've added a method to AmpAdLifecycleReporter that resets slotId and correlator, and any associated global values. Should this be called at somepoint in unlayoutCallback?
- ???