### PR TITLE
Update sauce documentation

### DIFF
--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -178,6 +178,7 @@ To run the tests on Sauce Labs:
    ```
 * It may take a few minutes for the tests to start.  You can see the status of your tests on the Sauce Labs [Automated Tests](https://saucelabs.com/beta/dashboard/tests) dashboard.  (You can also see the status of your proxy on the [Tunnels](https://saucelabs.com/beta/tunnels) dashboard.
 
+* If you see "Cannot find module '../build/safe-execute'", this is caused by a caching issue - try uninstalling and reinstalling the 'wd' module as described in [karma-sauce-launcher issue #117](https://github.com/karma-runner/karma-sauce-launcher/issues/117).
 
 ## Testing on devices
 


### PR DESCRIPTION
Adds a line to the doc about wd cache corruption issue that can arise when testing sauce labs